### PR TITLE
add setup.py to ease install and use of lxbuildenv

### DIFF
--- a/lxbuildenv.py
+++ b/lxbuildenv.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
     return True
 
 # For the main command, parse args and hand it off to main()
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         description="Wrap Python code to enable quickstart",
         add_help=False)
@@ -532,6 +532,9 @@ if __name__ == "__main__":
 
     if not lx_main(args):
         parser.print_help()
+
+if __name__ == "__main__":
+    main()
 
 elif not os.path.isfile(sys.argv[0]):
     print("lxbuildenv doesn't operate while in interactive mode")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+from setuptools import setup
+from setuptools import find_packages
+
+
+if sys.version_info[:3] < (3, 5):
+    raise SystemExit("You need Python 3.5+")
+
+print()
+
+setup(
+    name="lxbuildenv",
+    description="Simplified build environment for LiteX",
+    long_description=open("README.asciidoc").read(),
+    author="Sean Cross",
+    author_email="sean@xobs.io",
+    url="http://xobs.io",
+    download_url="https://github.com/xobs/lxbuildenv",
+    license="BSD",
+    platforms=["Any"],
+    keywords="HDL ASIC FPGA hardware design",
+    classifiers=[
+        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+        "Environment :: Console",
+        "Development Status :: Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+    ],
+    py_modules=["lxbuildenv"],
+    install_requires=[],
+    entry_points={
+        "console_scripts": [
+            "lxbuildenv=lxbuildenv:main",
+        ],
+    },
+)


### PR DESCRIPTION
Projects using lxbuildenv are duplicating lxbuildenv.py in the project (ex Fomu, Betrusted-io), this should probably be avoided to ease work/evolution/maintenance of lxbuildenv.

To simplify things, lxbuildenv could be the only required package to be installed prior building a project, then `lxbuildenv` command, `import lxbuildenv` would be available and would manage all the others dependencies as actually done.

This PR adds a setup.py to install lxbuildenv as a package to allow that. Previous use is still possible.