### PR TITLE
Add check for xPack GNU RISC-V Embedded GCC

### DIFF
--- a/lxbuildenv.py
+++ b/lxbuildenv.py
@@ -197,6 +197,11 @@ def check_riscv(args):
     if riscv32[0] == True:
         return riscv32
 
+    # See https://xpack.github.io/riscv-none-embed-gcc/#riscv64-unknown-elf-gcc
+    xpm_riscv = check_cmd(args, "riscv-none-embed-gcc", "xPack GNU RISC-V Embedded GCC", "install it from https://xpack.github.io/riscv-none-embed-gcc/install/")
+    if xpm_riscv[0] == True:
+        return xpm_riscv
+
     return riscv64
 
 def check_yosys(args):


### PR DESCRIPTION
I was testing out the litex example in https://github.com/gregdavill/OrangeCrab-examples and found that `lxbuildenv.py` didn't pick up the riscv toolchain I had previously installed from https://xpack.github.io/riscv-none-embed-gcc/install/ 

This PR adds a check for `riscv-none-embed-gcc`